### PR TITLE
Add tree dropdown menu

### DIFF
--- a/src/components/AppNav.js
+++ b/src/components/AppNav.js
@@ -1,0 +1,114 @@
+/* eslint-disable */
+
+/**
+ * Code fragment of a official quasar docs app
+ * Reference: https://github.com/quasarframework/quasar/blob/dev/docs/src/components/AppMenu.js
+**/
+
+import {
+  QExpansionItem,
+  QItem,
+  QItemSection,
+  QIcon,
+  QBadge,
+  QList
+} from 'quasar'
+
+import Menu from '../nav.js'
+import './AppNav.sass'
+
+export default {
+  name: 'AppNav',
+
+  watch: {
+    $route (route) {
+      this.showMenu(this.$refs[route.path])
+    }
+  },
+
+  methods: {
+    showMenu (comp) {
+      if (comp !== void 0 && comp !== this) {
+        this.showMenu(comp.$parent)
+        comp.show !== void 0 && comp.show()
+      }
+    },
+
+    getDrawerMenu (h, menu, path, level) {
+      if (menu.children !== void 0) {
+        return h(
+          QExpansionItem,
+          {
+            staticClass: 'non-selectable',
+            ref: path,
+            props: {
+              label: menu.name,
+              dense: level > 0,
+              icon: menu.icon,
+              defaultOpened: menu.opened,
+              expandSeparator: true,
+              switchToggleSide: level > 0,
+              denseToggle: level > 0
+            }
+          },
+          menu.children.map(item => this.getDrawerMenu(
+            h,
+            item,
+            path + (item.path !== void 0 ? '/' + item.path : ''),
+            level + 1
+          ))
+        )
+      }
+
+      const props = {
+        to: path,
+        dense: level > 0,
+        insetLevel: level > 1 ? 1.2 : level
+      }
+
+      const attrs = {}
+
+      if (menu.external === true) {
+        Object.assign(props, {
+          to: void 0,
+          clickable: true,
+          tag: 'a'
+        })
+
+        attrs.href = menu.path
+        attrs.target = '_blank'
+      }
+
+      return h(QItem, {
+        ref: path,
+        props,
+        attrs,
+        staticClass: 'app-menu-entry non-selectable'
+      }, [
+        menu.icon !== void 0
+          ? h(QItemSection, {
+            props: { avatar: true }
+          }, [ h(QIcon, { props: { name: menu.icon } }) ])
+          : null,
+
+        h(QItemSection, [ menu.name ]),
+
+        menu.badge !== void 0
+          ? h(QItemSection, {
+            props: { side: true }
+          }, [ h(QBadge, [ menu.badge ]) ])
+          : null
+      ])
+    }
+  },
+
+  render (h) {
+    return h(QList, { staticClass: 'app-menu' }, Menu.map(
+      item => this.getDrawerMenu(h, item, '/' + item.path, 0)
+    ))
+  },
+
+  mounted () {
+    this.showMenu(this.$refs[this.$route.path])
+  }
+}

--- a/src/components/AppNav.js
+++ b/src/components/AppNav.js
@@ -1,10 +1,5 @@
 /* eslint-disable */
 
-/**
- * Code fragment of a official quasar docs app
- * Reference: https://github.com/quasarframework/quasar/blob/dev/docs/src/components/AppMenu.js
-**/
-
 import {
   QExpansionItem,
   QItem,

--- a/src/components/AppNav.sass
+++ b/src/components/AppNav.sass
@@ -1,7 +1,4 @@
 
-// Code fragment of a official quasar docs app
-// Reference: https://github.com/quasarframework/quasar/blob/dev/docs/src/components/AppMenu.sass
-
 .app-menu
 
   .q-item__section--avatar

--- a/src/components/AppNav.sass
+++ b/src/components/AppNav.sass
@@ -1,0 +1,19 @@
+
+// Code fragment of a official quasar docs app
+// Reference: https://github.com/quasarframework/quasar/blob/dev/docs/src/components/AppMenu.sass
+
+.app-menu
+
+  .q-item__section--avatar
+    color: $primary
+
+  .q-expansion-item--expanded > div > .q-item > .q-item__section--main
+    color: $primary
+    font-weight: 700
+
+  .q-expansion-item__content .q-item
+    border-radius: 0 10px 10px 0
+    margin-right: 12px
+
+  .q-item.q-router-link--active
+    background: scale-color($primary, $lightness: 90%)

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -25,6 +25,14 @@
       bordered
       content-class="bg-grey-1"
     >
+      <q-item-label
+        header
+        class="text-grey-8"
+      >
+        Dashboard
+      </q-item-label>
+      <app-nav></app-nav>
+
       <q-list>
         <q-item-label
           header
@@ -39,7 +47,6 @@
         />
       </q-list>
     </q-drawer>
-
     <q-page-container>
       <router-view />
     </q-page-container>
@@ -48,11 +55,13 @@
 
 <script>
 import EssentialLink from 'components/EssentialLink'
+import AppNav from '../components/AppNav'
 
 export default {
   name: 'MainLayout',
 
   components: {
+    AppNav,
     EssentialLink
   },
 

--- a/src/nav.js
+++ b/src/nav.js
@@ -1,0 +1,26 @@
+
+module.exports = [
+  {
+    name: 'Panel',
+    label: 'teste',
+    icon: 'dashboard',
+    path: ''
+  },
+  {
+    name: 'Menu item',
+    icon: 'list',
+    path: '#',
+    children: [
+      {
+        name: 'sub item 1',
+        path: '#',
+        children: [
+          {
+            name: 'sub item 2',
+            path: '#'
+          }
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
**Implementation**: Add tree dropdown menu.

**Motivation**: The app needs provide a component to add items to the panel menu.

**Feature**: The menu can be configured by nav.js file. The dom can detect if the page reload to activate the relative item for the actual route.

**P.S**: Code copied from the quasar.dev
 **Reference**: _https://github.com/quasarframework/quasar/blob/dev/docs/src/components/AppMenu.js_


**Preview:**

![image](https://user-images.githubusercontent.com/11599205/76585051-25430580-64bc-11ea-8022-ec503a423f31.png)
